### PR TITLE
Support pre-Iron distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cproject
 .project
+COLCON_IGNORE

--- a/include/web_video_server/web_video_server.h
+++ b/include/web_video_server/web_video_server.h
@@ -2,7 +2,13 @@
 #define WEB_VIDEO_SERVER_H_
 
 #include <rclcpp/rclcpp.hpp>
-#include <cv_bridge/cv_bridge.hpp>
+
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>  // For ROS Iron and up.
+#else
+#include <cv_bridge/cv_bridge.h>  // For ROS Humble and below
+#endif
+
 #include <vector>
 #include "web_video_server/image_streamer.h"
 #include "async_web_server_cpp/http_server.hpp"

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -1,5 +1,9 @@
 #include "web_video_server/image_streamer.h"
-#include <cv_bridge/cv_bridge.hpp>
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>  // For ROS Iron and up.
+#else
+#include <cv_bridge/cv_bridge.h>  // For ROS Humble and below
+#endif
 #include <iostream>
 
 namespace web_video_server


### PR DESCRIPTION
Added header preprocessing to make the required nodehandle patch useable with ROS humble. (Due to the changes in `cv_bridge` headers)
